### PR TITLE
:sparkles: add option to filter priority items in the action list

### DIFF
--- a/frame/App/Body/Main/Column.js
+++ b/frame/App/Body/Main/Column.js
@@ -32,6 +32,8 @@ type Props = {
   title?: string,
   showCompleted?: boolean,
   setShowCompleted?: ((boolean => boolean) | boolean) => void,
+  showFlagged?: boolean,
+  setShowFlagged?: ((boolean => boolean) | boolean) => void,
   listId: string,
   onListDeletion?: (listId: string) => void,
 };
@@ -44,6 +46,8 @@ const Column = ({
   setShowCompleted,
   listId,
   onListDeletion,
+  showFlagged = false,
+  setShowFlagged,
 }: Props): React.Node => {
   const [activeColumn, setActiveColumn] = React.useState(false);
   const [isToday, setIsToday] = React.useState(false);
@@ -135,6 +139,8 @@ const Column = ({
               setShowCompleted={setShowCompleted}
               listId={listId}
               onListDeletion={onListDeletion}
+              showFlagged={showFlagged}
+              setShowFlagged={setShowFlagged}
             />
           )}
         </Box>

--- a/frame/App/Body/Main/DailyLists/DailyTodo.js
+++ b/frame/App/Body/Main/DailyLists/DailyTodo.js
@@ -13,11 +13,13 @@ import Column from '../Column';
 type Props = {
   ...ListT,
   showCompleted: boolean,
+  showFlagged: boolean,
 };
 
 const DailyTodo = ({
   id,
   showCompleted,
+  showFlagged,
 }: Props): React.Node => {
   const [items, setItems] = React.useState([]);
 
@@ -33,6 +35,7 @@ const DailyTodo = ({
     setItems(newItems);
   }, {
     completed: showCompleted,
+    flagged: showFlagged,
   });
 
   return (

--- a/frame/App/Body/Main/DailyLists/ListSwitcher.js
+++ b/frame/App/Body/Main/DailyLists/ListSwitcher.js
@@ -16,6 +16,8 @@ type Props = {
   showCompleted: boolean,
   setShowCompleted: ((boolean => boolean) | boolean) => void,
   onListDeletion: (listId: string) => void,
+  showFlagged: boolean,
+  setShowFlagged: ((boolean => boolean) | boolean) => void,
 };
 
 const ListSwitcher = ({
@@ -26,6 +28,8 @@ const ListSwitcher = ({
   showCompleted,
   setShowCompleted,
   onListDeletion,
+  showFlagged,
+  setShowFlagged,
 }: Props): React.Node => {
   const firebase = useFirebase();
 
@@ -151,6 +155,8 @@ const ListSwitcher = ({
           setListId('');
           setName('');
         }}
+        showFlagged={showFlagged}
+        setShowFlagged={setShowFlagged}
       />
     </Box>
   );

--- a/frame/App/Body/Main/DailyLists/index.js
+++ b/frame/App/Body/Main/DailyLists/index.js
@@ -21,6 +21,7 @@ const DailyLists = ({
   const [listName, setListName] = React.useState(dailyLists[0]?.name);
   const list = dailyLists.filter((o) => o.name === listName)[0];
   const [showCompleted, setShowCompleted] = React.useState(false);
+  const [showFlagged, setShowFlagged] = React.useState(false);
 
   return (
     <Box
@@ -39,10 +40,13 @@ const DailyLists = ({
         showCompleted={showCompleted}
         setShowCompleted={setShowCompleted}
         onListDeletion={onListDeletion}
+        showFlagged={showFlagged}
+        setShowFlagged={setShowFlagged}
       />
       {listName && dailyLists && (
         <DailyTodo
           showCompleted={showCompleted}
+          showFlagged={showFlagged}
           {...list}
         />
       )}

--- a/frame/App/Body/Main/GenericLists/ListTodo.js
+++ b/frame/App/Body/Main/GenericLists/ListTodo.js
@@ -22,12 +22,16 @@ const ListTodo = ({
   onListDeletion,
 }: Props): React.Node => {
   const [showCompleted, setShowCompleted] = React.useState(false);
+  const [showFlagged, setShowFlagged] = React.useState(false);
   const [items, setItems] = React.useState([]);
   const [openModal, setOpenModal] = React.useState(false);
 
   useGetListItems(id, (newItems) => {
     setItems(newItems);
-  }, { completed: showCompleted });
+  }, {
+    completed: showCompleted,
+    flagged: showFlagged,
+  });
 
   return (
     <div>
@@ -52,6 +56,8 @@ const ListTodo = ({
           setShowCompleted={setShowCompleted}
           listId={id}
           onListDeletion={onListDeletion}
+          showFlagged={showFlagged}
+          setShowFlagged={setShowFlagged}
         >
           <AddItem
             listId={id}

--- a/frame/App/Body/Main/components/ListActions.js
+++ b/frame/App/Body/Main/components/ListActions.js
@@ -13,6 +13,8 @@ type Props = {
   title?: string,
   showCompleted?: boolean,
   setShowCompleted?: ((boolean => boolean) | boolean) => void,
+  showFlagged: boolean,
+  setShowFlagged?: ((boolean =>boolean) | boolean) => void,
   listId: string,
   onListDeletion?: (listId: string) => void,
 };
@@ -21,6 +23,8 @@ const ListActions = ({
   title,
   showCompleted = false,
   setShowCompleted,
+  showFlagged = false,
+  setShowFlagged,
   listId,
   onListDeletion,
 }: Props): React.Node => {
@@ -107,7 +111,17 @@ const ListActions = ({
                     }}
                     type="checkbox"
                   />
-                  show completed
+                  Show Completed
+                </div>
+                <div>
+                  <input
+                    value={showFlagged}
+                    onChange={() => {
+                      setShowFlagged && setShowFlagged((pshowFlagged) => !pshowFlagged);
+                    }}
+                    type="checkbox"
+                  />
+                  Filter Priority
                 </div>
                 <Button
                   onClick={() => setConfirmDelete(true)}

--- a/packages/core/service/index.js
+++ b/packages/core/service/index.js
@@ -9,6 +9,7 @@ export const useGetListItems = (
   callback: (items: Array<ListItemT>) => void,
   options?: {
     completed?: boolean,
+    flagged?: boolean,
     ...
   } = {},
 ) => {
@@ -30,7 +31,11 @@ export const useGetListItems = (
 
     let unsubscribe;
 
-    if (!options.completed) {
+    if (options.flagged) {
+      unsubscribe = itemCollection.where('priority', '==', true).onSnapshot((snapshot) => {
+        updateItems(snapshot);
+      });
+    } else if (!options.completed) {
       unsubscribe = itemCollection.where('completed', '==', false).onSnapshot((snapshot) => {
         updateItems(snapshot);
       });
@@ -43,5 +48,5 @@ export const useGetListItems = (
     return () => {
       unsubscribe && unsubscribe();
     };
-  }, [listId, options.completed]);
+  }, [listId, options.completed, options.flagged]);
 };


### PR DESCRIPTION
User can now filter the lists based on the priority. If Any item is flagged, then its priority is set to true. So the user can now display only the priority items in the Daily Lists and Lists view 

https://user-images.githubusercontent.com/9144651/137643595-9ab45933-10d8-4f6a-8f1c-125681215204.mov

